### PR TITLE
Fix calculation of number of jets

### DIFF
--- a/producers/fatjets.py
+++ b/producers/fatjets.py
@@ -207,14 +207,14 @@ LVFatJet2 = Producer(
 
 NumberOfFatJets = Producer(
     name="NumberOfFatJets",
-    call="physicsobject::Count({df}, {output}, {input})",
+    call="physicsobject::Size<Int_t>({df}, {output}, {input})",
     input=[q.good_fatjet_collection],
     output=[q.nfatjets],
     scopes=["mt", "et", "tt", "em", "mm", "ee"],
 )
 NumberOfFatJets_boosted = Producer(
     name="NumberOfFatJets_boosted",
-    call="physicsobject::Count({df}, {output}, {input})",
+    call="physicsobject::Size<Int_t>({df}, {output}, {input})",
     input=[q.good_fatjet_collection_boosted],
     output=[q.nfatjets_boosted],
     scopes=["mt", "et", "tt", "em", "mm", "ee"],

--- a/producers/jets.py
+++ b/producers/jets.py
@@ -392,14 +392,14 @@ LVJet2 = Producer(
 )
 NumberOfJets = Producer(
     name="NumberOfJets",
-    call="physicsobject::Count({df}, {output}, {input})",
+    call="physicsobject::Size<Int_t>({df}, {output}, {input})",
     input=[q.good_jet_collection],
     output=[q.njets],
     scopes=SCOPES,
 )
 NumberOfJets_boosted = Producer(
     name="NumberOfJets_boosted",
-    call="physicsobject::Count({df}, {output}, {input})",
+    call="physicsobject::Size<Int_t>({df}, {output}, {input})",
     input=[q.good_jet_collection_boosted],
     output=[q.njets_boosted],
     scopes=SCOPES,
@@ -523,14 +523,14 @@ LVBJet2 = Producer(
 )
 NumberOfBJets = Producer(
     name="NumberOfBJets",
-    call="physicsobject::Count({df}, {output}, {input})",
+    call="physicsobject::Size<Int_t>({df}, {output}, {input})",
     input=[q.good_bjet_collection],
     output=[q.nbtag],
     scopes=SCOPES,
 )
 NumberOfBJets_boosted = Producer(
     name="NumberOfBJets_boosted",
-    call="physicsobject::Count({df}, {output}, {input})",
+    call="physicsobject::Size<Int_t>({df}, {output}, {input})",
     input=[q.good_bjet_collection_boosted],
     output=[q.nbtag_boosted],
     scopes=SCOPES,

--- a/producers/jets.py
+++ b/producers/jets.py
@@ -118,7 +118,7 @@ GoodJetsWithPUID = Producer(
 
 # jet selection not applying the pileup ID (for PUPPI jets)
 GoodJetsWithoutPUID = Producer(
-    name="GoodJetsWithPUID",
+    name="GoodJetsWithoutPUID",
     call="xyh::object_selection::jet({df}, {output}, {input}, {ak4jet_min_pt}, {ak4jet_max_abs_eta}, {ak4jet_id_wp})",
     input=[
         q.Jet_pt_corrected,
@@ -193,7 +193,7 @@ GoodBJetsWithPUID = ProducerGroup(
 
 # combined jet-bjet mask (OR)
 GoodJetsCombinedWithoutPUID = Producer(
-    name="GoodJetsWithoutPUID",
+    name="GoodJetsCombinedWithoutPUID",
     call='physicsobject::CombineMasks({df}, {output}, {input}, "any_of")',
     input=[q.good_jets_mask, q.good_bjets_mask],
     output=[q.good_jets_combined_mask],


### PR DESCRIPTION
This pull request fixes the calculation of the number of jets, which leads to wrong results if `physicsobject::Count` is used. For the producers `NumberOfJets` and `NumberOfBJets`, the call of this function is replaced with `physicsobject::Size<int>`, which is going to be introduced with https://github.com/KIT-CMS/CROWN/pull/337.

Comment: The error occurs because `Nonzero` is used in `physicsobject::Count`, which leads to wrong results if the index 0 appears in a collection index list. This means that `Count` evaluates to `2` for an index list like `ROOT::RVec({0, 1, 2})`, instead of the true value of `3`.