### PR TITLE
Preliminary tau scale factors calculated with new DY samples

### DIFF
--- a/nmssm_config.py
+++ b/nmssm_config.py
@@ -896,7 +896,7 @@ def add_hadronic_tau_config(configuration: Configuration):
             "tau_sf_vsjet_tau40to500": "nom",
             "tau_sf_vsjet_tau500to1000": "nom",
             "tau_sf_vsjet_tau1000toinf": "nom",
-            "tau_vsjet_sf_dependence": "pt",  # or "dm", "eta"
+            "tau_vsjet_sf_dependence": "dm",  # or "dm", "eta"
         },
     )
 

--- a/nmssm_config.py
+++ b/nmssm_config.py
@@ -698,7 +698,7 @@ def add_hadronic_tau_config(configuration: Configuration):
                         for _era, _campaign in CORRECTIONLIB_CAMPAIGNS.items()
                         if _era in ERAS_RUN2
                     },
-                    "2022preEE": "data/jsonpog-integration/POG/TAU/2022_Summer22/tau_DeepTau2018v2p5_2022_preEE.json.gz",
+                    "2022preEE": "payloads/preliminary_tau_corrections/tau_DeepTau2018v2p5_2022_preEE.json.gz",
                     "2022postEE": "data/jsonpog-integration/POG/TAU/2022_Summer22EE/tau_DeepTau2018v2p5_2022_postEE.json.gz",
                     "2023preBPix": "data/jsonpog-integration/POG/TAU/2023_Summer23/tau_DeepTau2018v2p5_2023_preBPix.json.gz",
                     "2023postBPix": "data/jsonpog-integration/POG/TAU/2023_Summer23BPix/tau_DeepTau2018v2p5_2023_postBPix.json.gz",


### PR DESCRIPTION
This pull request adds preliminary scale factor files for tau ID and ES corrections, calculated with new DY samples. The results are taken from this presentation: https://indico.cern.ch/event/1574211/.

Two files are now loaded: The new preliminary SFs for tau ID and ES corrections and the old, official `jsonPOG` file for the trigger scale factors.