### PR TITLE
Implementation of jet horn vetoes

### DIFF
--- a/cpp_addons/include/object_selection.hxx
+++ b/cpp_addons/include/object_selection.hxx
@@ -171,7 +171,8 @@ ROOT::RDF::RNode jet(
     const std::string &jet_id,
     const float &min_pt,
     const float &abs_max_eta,
-    const int &id_wp
+    const int &id_wp,
+    const bool &apply_jet_horn_veto
 );
 
 // function xyh::object_selection::jet (overloaded version with pileup ID)
@@ -185,6 +186,7 @@ ROOT::RDF::RNode jet(
     const float &min_pt,
     const float &abs_max_eta,
     const int &id_wp,
+    const bool &apply_jet_horn_veto,
     const int &puid_wp,
     const float &puid_max_pt
 );

--- a/cpp_addons/src/object_selection.cxx
+++ b/cpp_addons/src/object_selection.cxx
@@ -315,10 +315,14 @@ namespace xyh {
          * @param min_pt The minimum transverse momentum for selected jets.
          * @param abs_max_eta The maximum absolute pseudorapidity for selected jets.
          * @param id_wp The working point for the jet identification.
+         * @param apply_jet_horn_veto Whether to apply the jet horn veto.
          * @return A new data frame with the selection mask column.
          * 
          * @note The function does not apply pileup ID, as it is not present for PFPuppi jets.
- *       *       If it should be applied, use the overloaded function with pileup ID.
+         *       If it should be applied, use the overloaded function with pileup ID.
+         *
+         * @note The jet horn veto removes jets in the pseudorapidity range \(2.5 < |\eta| < 3.0\) with a
+         *       transverse momentum \(p_T < 50\) GeV.
          */
         ROOT::RDF::RNode jet(
             ROOT::RDF::RNode df,
@@ -328,10 +332,11 @@ namespace xyh {
             const std::string &jet_id,
             const float &min_pt,
             const float &abs_max_eta,
-            const int &id_wp
+            const int &id_wp,
+            const bool &apply_jet_horn_veto
         ) {
             auto select = [
-                min_pt, abs_max_eta, id_wp
+                min_pt, abs_max_eta, id_wp, apply_jet_horn_veto
             ] (
                 const ROOT::RVec<float> &pt,
                 const ROOT::RVec<float> &eta,
@@ -345,7 +350,7 @@ namespace xyh {
                 Logger::get("xyh::object_selection::jet")->debug("    id {}", id);
 
                 // create the selection mask
-                auto mask = xyh::object_selection::select_jet(pt, eta, id, min_pt, abs_max_eta, id_wp);
+                auto mask = xyh::object_selection::select_jet(pt, eta, id, min_pt, abs_max_eta, id_wp, apply_jet_horn_veto);
 
                 // debug output for the final selection mask
                 Logger::get("xyh::object_selection::jet")->debug("    selection mask {}", mask);
@@ -382,10 +387,16 @@ namespace xyh {
          * @param min_pt The minimum transverse momentum for selected jets.
          * @param abs_max_eta The maximum absolute pseudorapidity for selected jets.
          * @param id_wp The working point for the jet identification.
+         * @param apply_jet_horn_veto Whether to apply the jet horn veto.
+         * @param puid_wp The working point for the jet pileup identification.
+         * @param puid_max_pt The maximum transverse momentum for the pileup identification.
          * @return A new data frame with the selection mask column.
          * 
          * @note The function applies pileup ID.
          *       If it should not be applied, use the overloaded function with pileup ID.
+         *
+         * @note The jet horn veto removes jets in the pseudorapidity range \(2.5 < |\eta| < 3.0\) with a
+         *       transverse momentum \(p_T < 50\) GeV.
          */
         ROOT::RDF::RNode jet(
             ROOT::RDF::RNode df,
@@ -397,11 +408,12 @@ namespace xyh {
             const float &min_pt,
             const float &abs_max_eta,
             const int &id_wp,
+            const bool &apply_jet_horn_veto,
             const int &puid_wp,
             const float &puid_max_pt
         ) {
             auto select = [
-                min_pt, abs_max_eta, id_wp, puid_wp, puid_max_pt
+                min_pt, abs_max_eta, id_wp, puid_wp, puid_max_pt, apply_jet_horn_veto
             ] (
                 const ROOT::RVec<float> &pt,
                 const ROOT::RVec<float> &eta,
@@ -417,7 +429,7 @@ namespace xyh {
                 Logger::get("xyh::object_selection::jet")->debug("    puid {}", puid);
 
                 // create the selection mask
-                auto mask = xyh::object_selection::select_jet(pt, eta, id, puid, min_pt, abs_max_eta, id_wp, puid_wp, puid_max_pt);
+                auto mask = xyh::object_selection::select_jet(pt, eta, id, puid, min_pt, abs_max_eta, id_wp, apply_jet_horn_veto, puid_wp, puid_max_pt);
 
                 // debug output for the final selection mask
                 Logger::get("xyh::object_selection::jet")->debug("    selection mask {}", mask);

--- a/nmssm_config.py
+++ b/nmssm_config.py
@@ -1172,6 +1172,7 @@ def add_ak4jet_config(configuration: Configuration):
             "ak4jet_min_pt": 30.0,
             "ak4jet_max_abs_eta": 4.7,
             "ak4jet_id_wp": 2,  # 0 == fail, 2 == pass(tight) & fail(tightLepVeto), 6 == pass(tight) & pass(tightLepVeto)
+            "ak4jet_apply_jet_horn_veto": "true",
             "ak4jet_puid_wp": EraModifier(
                 {
                     "2016preVFP": 1,  # 0 == fail, 1 == pass(loose), 3 == pass(loose,medium), 7 == pass(loose,medium,tight)
@@ -1318,6 +1319,7 @@ def add_ak8jet_config(configuration: Configuration):
             "ak8jet_min_pt": 200.,
             "ak8jet_max_abs_eta": 2.5,
             "ak8jet_id_wp": 2,  # tight & tightLepVeto
+            "ak8jet_apply_jet_horn_veto": "true",
             "ak8jet_reapplyJES": False,
             "ak8jet_jes_sources": '{""}',
             "ak8jet_jes_shift": 0,

--- a/producers/_helpers.py
+++ b/producers/_helpers.py
@@ -163,7 +163,8 @@ def jerc_producer_factory(
                 f"{{{config_parameter_prefix}_reapplyJES}}, "
                 f"{{{config_parameter_prefix}_jes_shift}}, "
                 f"{{{config_parameter_prefix}_jer_shift}}, "
-                f"{lhc_run}"
+                f"{lhc_run}, "
+                f"{{{config_parameter_prefix}_apply_jet_horn_veto}}"
             ")"
         ),
         input=[

--- a/producers/fatjets.py
+++ b/producers/fatjets.py
@@ -84,7 +84,7 @@ FatJetEnergyCorrection_data, FatJetEnergyCorrection, RenameFatJetsData = jerc_pr
 # jet selection not applying the pileup ID (for PUPPI jets)
 GoodFatJetsWithoutPUID = Producer(
     name="GoodFatJetsWithPUID",
-    call="xyh::object_selection::jet({df}, {output}, {input}, {ak8jet_min_pt}, {ak8jet_max_abs_eta}, {ak8jet_id_wp})",
+    call="xyh::object_selection::jet({df}, {output}, {input}, {ak8jet_min_pt}, {ak8jet_max_abs_eta}, {ak8jet_id_wp}, {ak8jet_apply_jet_horn_veto})",
     input=[
         q.FatJet_pt_corrected,
         nanoAOD.FatJet_eta,

--- a/producers/jets.py
+++ b/producers/jets.py
@@ -105,7 +105,7 @@ JetIDRun2 = Producer(
 # jet selection including the pileup ID (for CHS jets)
 GoodJetsWithPUID = Producer(
     name="GoodJetsWithPUID",
-    call="xyh::object_selection::jet({df}, {output}, {input}, {ak4jet_min_pt}, {ak4jet_max_abs_eta}, {ak4jet_id_wp}, {ak4jet_puid_wp}, {ak4jet_puid_max_pt})",
+    call="xyh::object_selection::jet({df}, {output}, {input}, {ak4jet_min_pt}, {ak4jet_max_abs_eta}, {ak4jet_id_wp}, {ak4jet_apply_jet_horn_veto}, {ak4jet_puid_wp}, {ak4jet_puid_max_pt})",
     input=[
         q.Jet_pt_corrected,
         nanoAOD.Jet_eta,
@@ -119,7 +119,7 @@ GoodJetsWithPUID = Producer(
 # jet selection not applying the pileup ID (for PUPPI jets)
 GoodJetsWithoutPUID = Producer(
     name="GoodJetsWithoutPUID",
-    call="xyh::object_selection::jet({df}, {output}, {input}, {ak4jet_min_pt}, {ak4jet_max_abs_eta}, {ak4jet_id_wp})",
+    call="xyh::object_selection::jet({df}, {output}, {input}, {ak4jet_min_pt}, {ak4jet_max_abs_eta}, {ak4jet_id_wp}, {ak4jet_apply_jet_horn_veto})",
     input=[
         q.Jet_pt_corrected,
         nanoAOD.Jet_eta,
@@ -132,7 +132,7 @@ GoodJetsWithoutPUID = Producer(
 # base jet selection for b jets including the pileup ID (for CHS jets)
 GoodBJetsBaseWithPUID = Producer(
     name="GoodBJetsBaseWithPUID",
-    call="xyh::object_selection::jet({df}, {output}, {input}, {bjet_min_pt}, {bjet_max_abs_eta}, {ak4jet_id_wp}, {ak4jet_puid_wp}, {ak4jet_puid_max_pt})",
+    call="xyh::object_selection::jet({df}, {output}, {input}, {bjet_min_pt}, {bjet_max_abs_eta}, {ak4jet_id_wp}, {ak4jet_apply_jet_horn_veto}, {ak4jet_puid_wp}, {ak4jet_puid_max_pt})",
     input=[
         q.Jet_pt_corrected,
         nanoAOD.Jet_eta,
@@ -146,7 +146,7 @@ GoodBJetsBaseWithPUID = Producer(
 # base jet selection for b jets not applying the pileup ID (for PUPPI jets)
 GoodBJetsBaseWithoutPUID = Producer(
     name="GoodBJetsBaseWithoutPUID",
-    call="xyh::object_selection::jet({df}, {output}, {input}, {bjet_min_pt}, {bjet_max_abs_eta}, {ak4jet_id_wp})",
+    call="xyh::object_selection::jet({df}, {output}, {input}, {bjet_min_pt}, {bjet_max_abs_eta}, {ak4jet_id_wp}, {ak4jet_apply_jet_horn_veto})",
     input=[
         q.Jet_pt_corrected,
         nanoAOD.Jet_eta,


### PR DESCRIPTION
This pull request adds jet horn vetoes to selection functions for jets. Jets are vetoed if they have p<sub>T</sub> <  50 GeV and |&eta;| > 2.5 and |&eta;| < 3.0. In addition, the JER smearing is not applied to jets for |&eta;| > 2.5 if they are not matched to a generator-level jet (CROWN function introduced in https://github.com/KIT-CMS/CROWN/pull/344).