### PR TITLE
Simplify setup of sample flags

### DIFF
--- a/nmssm_config.py
+++ b/nmssm_config.py
@@ -1548,7 +1548,9 @@ def build_config(
         available_scopes,
     )
 
-    # set sample flags manually
+    # Set sample flags manually
+    # The configuration of is_data and is_embedding is set here for better readability, although
+    # it has already been set in the Configuration class.
     configuration.add_config_parameters(
         GLOBAL_SCOPES,
         {

--- a/nmssm_config.py
+++ b/nmssm_config.py
@@ -1548,6 +1548,16 @@ def build_config(
         available_scopes,
     )
 
+    # set sample flags manually
+    configuration.add_config_parameters(
+        GLOBAL_SCOPES,
+        {
+            "is_data": sample == "data",
+            "is_embedding": sample == "embedding",
+            "is_mc": sample not in ["data", "embedding"],
+        },
+    )
+
     # noise filters
     add_noise_filters_config(configuration)
 
@@ -2552,12 +2562,7 @@ def build_config(
         [
             q.is_data,
             q.is_embedding,
-            q.is_ttbar,
-            q.is_dyjets,
-            q.is_wjets,
-            q.is_ggh_htautau,
-            q.is_vbf_htautau,
-            q.is_diboson,
+            q.is_mc,
             nanoAOD.run,
             q.lumi,
             q.npartons,

--- a/producers/event.py
+++ b/producers/event.py
@@ -51,95 +51,12 @@ is_embedding = Producer(
     output=[q.is_embedding],
     scopes=["global"],
 )
-is_ttbar = Producer(
-    name="is_ttbar",
-    call="event::quantity::Define({df}, {output}, {is_ttbar})",
+
+is_mc = Producer(
+    name="is_mc",
+    call="event::quantity::Define({df}, {output}, {is_mc})",
     input=[],
-    output=[q.is_ttbar],
-    scopes=["global"],
-)
-is_dyjets = Producer(
-    name="is_dyjets",
-    call="event::quantity::Define({df}, {output}, {is_dyjets})",
-    input=[],
-    output=[q.is_dyjets],
-    scopes=["global"],
-)
-is_wjets = Producer(
-    name="is_wjets",
-    call="event::quantity::Define({df}, {output}, {is_wjets})",
-    input=[],
-    output=[q.is_wjets],
-    scopes=["global"],
-)
-is_ggh_htautau = Producer(
-    name="is_ggh_htautau",
-    call="event::quantity::Define({df}, {output}, {is_ggh_htautau})",
-    input=[],
-    output=[q.is_ggh_htautau],
-    scopes=["global"],
-)
-is_vbf_htautau = Producer(
-    name="is_vbf_htautau",
-    call="event::quantity::Define({df}, {output}, {is_vbf_htautau})",
-    input=[],
-    output=[q.is_vbf_htautau],
-    scopes=["global"],
-)
-is_diboson = Producer(
-    name="is_diboson",
-    call="event::quantity::Define({df}, {output}, {is_diboson})",
-    input=[],
-    output=[q.is_diboson],
-    scopes=["global"],
-)
-is_ggh_hbb = Producer(
-    name="is_ggh_hbb",
-    call="event::quantity::Define({df}, {output}, {is_ggh_hbb})",
-    input=[],
-    output=[q.is_ggh_hbb],
-    scopes=["global"],
-)
-is_vbf_hbb = Producer(
-    name="is_vbf_hbb",
-    call="event::quantity::Define({df}, {output}, {is_vbf_hbb})",
-    input=[],
-    output=[q.is_vbf_hbb],
-    scopes=["global"],
-)
-is_rem_hbb = Producer(
-    name="is_rem_hbb",
-    call="event::quantity::Define({df}, {output}, {is_rem_hbb})",
-    input=[],
-    output=[q.is_rem_hbb],
-    scopes=["global"],
-)
-is_embedding_mc = Producer(
-    name="is_embedding_mc",
-    call="event::quantity::Define({df}, {output}, {is_embedding_mc})",
-    input=[],
-    output=[q.is_embedding_mc],
-    scopes=["global"],
-)
-is_singletop = Producer(
-    name="is_singletop",
-    call="event::quantity::Define({df}, {output}, {is_singletop})",
-    input=[],
-    output=[q.is_singletop],
-    scopes=["global"],
-)
-is_rem_htautau = Producer(
-    name="is_singletop",
-    call="event::quantity::Define({df}, {output}, {is_rem_htautau})",
-    input=[],
-    output=[q.is_rem_htautau],
-    scopes=["global"],
-)
-is_electroweak_boson = Producer(
-    name="is_singletop",
-    call="event::quantity::Define({df}, {output}, {is_electroweak_boson})",
-    input=[],
-    output=[q.is_electroweak_boson],
+    output=[q.is_mc],
     scopes=["global"],
 )
 
@@ -152,19 +69,7 @@ SampleFlags = ProducerGroup(
     subproducers=[
         is_data,
         is_embedding,
-        is_ttbar,
-        is_dyjets,
-        is_wjets,
-        is_ggh_htautau,
-        is_vbf_htautau,
-        is_diboson,
-        is_ggh_hbb,
-        is_vbf_hbb,
-        is_rem_hbb,
-        is_embedding_mc,
-        is_singletop,
-        is_rem_htautau,
-        is_electroweak_boson,
+        is_mc,
     ],
 )
 

--- a/quantities/output.py
+++ b/quantities/output.py
@@ -546,20 +546,7 @@ emb_idsel_wgt_2 = Quantity("emb_idsel_wgt_2")
 # sample flags
 is_data = Quantity("is_data")
 is_embedding = Quantity("is_embedding")
-is_ttbar = Quantity("is_ttbar")
-is_dyjets = Quantity("is_dyjets")
-is_wjets = Quantity("is_wjets")
-is_ggh_htautau = Quantity("is_ggh_htautau")
-is_vbf_htautau = Quantity("is_vbf_htautau")
-is_diboson = Quantity("is_diboson")
-is_vbf_hbb = Quantity("is_vbf_hbb")
-is_ggh_hbb = Quantity("is_ggh_hbb")
-is_rem_hbb = Quantity("is_rem_hbb")
-is_embedding_mc = Quantity("is_embedding_mc")
-is_singletop = Quantity("is_singletop")
-is_rem_htautau = Quantity("is_rem_htautau")
-is_electroweak_boson = Quantity("is_electroweak_boson")
-
+is_mc = Quantity("is_mc")
 
 # Electron Weights
 reco_wgt_ele_1 = Quantity("reco_wgt_ele_1")


### PR DESCRIPTION
The setup of the sample flags is simplified. Instead of writing a flag for each considered sample type to the output file, we only define flags `is_data`, `is_embedding`, and `is_mc`. All other distinctions between samples are not based on these flags anyway.