### PR TITLE
Add additional triggers

### DIFF
--- a/build_scripts/test_build_2022postEE.sh
+++ b/build_scripts/test_build_2022postEE.sh
@@ -32,7 +32,7 @@ main () {
 
     # split the samples string into an array
     if [[ "${samples}" == "all" ]]; then
-        samples="data,nmssm_Ybb,ttbar,dyjets_amcatnlo"
+        samples="data,nmssm_Ybb,ttbar,dyjets_amcatnlo_ll"
     fi
     declare -a samples_list
     IFS="," read -ra samples_list <<< "${samples}"
@@ -47,7 +47,7 @@ main () {
     test_files_list[data]="root://xrootd-cms.infn.it///store/data/Run2022E/Muon/NANOAOD/22Sep2023-v1/40000/cb3afe1f-699f-4be6-a1ed-dd6fd0b2ca81.root"
     test_files_list[nmssm_Ybb]="root://xrootd-cms.infn.it///store/mc/Run3Summer22EENanoAODv12/NMSSM_XtoYHto2B2Tau_MX-1000_MY-100_TuneCP5_13p6TeV_madgraph-pythia8/NANOAODSIM/130X_mcRun3_2022_realistic_postEE_v6-v2/2830000/da15832e-6657-4d0c-bfb3-7641b5b6bc9e.root"
     test_files_list[ttbar]="root://xrootd-cms.infn.it///store/mc/Run3Summer22EENanoAODv12/TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/NANOAODSIM/130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/50000/fce23976-3083-4220-ab86-abfde0dc2c2f.root"
-    test_files_list[dyjets_amcatnlo]="root://xrootd-cms.infn.it///store/mc/Run3Summer22EENanoAODv12/DYto2L-2Jets_MLL-50_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/NANOAODSIM/130X_mcRun3_2022_realistic_postEE_v6-v2/60000/27b270df-2d16-4b51-8617-84b2abb37000.root"
+    test_files_list[dyjets_amcatnlo_ll]="root://xrootd-cms.infn.it///store/mc/Run3Summer22EENanoAODv12/DYto2L-2Jets_MLL-50_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/NANOAODSIM/130X_mcRun3_2022_realistic_postEE_v6-v2/60000/27b270df-2d16-4b51-8617-84b2abb37000.root"
 
     # configure and compile the project
     if [[ "${steps}" == "build" || "${steps}" == "all" ]]; then

--- a/build_scripts/test_build_2022postEE.sh
+++ b/build_scripts/test_build_2022postEE.sh
@@ -47,7 +47,7 @@ main () {
     test_files_list[data]="root://xrootd-cms.infn.it///store/data/Run2022E/Muon/NANOAOD/22Sep2023-v1/40000/cb3afe1f-699f-4be6-a1ed-dd6fd0b2ca81.root"
     test_files_list[nmssm_Ybb]="root://xrootd-cms.infn.it///store/mc/Run3Summer22EENanoAODv12/NMSSM_XtoYHto2B2Tau_MX-1000_MY-100_TuneCP5_13p6TeV_madgraph-pythia8/NANOAODSIM/130X_mcRun3_2022_realistic_postEE_v6-v2/2830000/da15832e-6657-4d0c-bfb3-7641b5b6bc9e.root"
     test_files_list[ttbar]="root://xrootd-cms.infn.it///store/mc/Run3Summer22EENanoAODv12/TTto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/NANOAODSIM/130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/50000/fce23976-3083-4220-ab86-abfde0dc2c2f.root"
-    test_files_list[dyjets_amcatnlo_ll]="root://xrootd-cms.infn.it///store/mc/Run3Summer22EENanoAODv12/DYto2L-2Jets_MLL-50_1J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/NANOAODSIM/130X_mcRun3_2022_realistic_postEE_v6-v2/60000/27b270df-2d16-4b51-8617-84b2abb37000.root"
+    test_files_list[dyjets_amcatnlo_ll]="root://xrootd-cms.infn.it///store/mc/Run3Summer22EENanoAODv12/DYto2L-2Jets_MLL-50_0J_TuneCP5_13p6TeV_amcatnloFXFX-pythia8/NANOAODSIM/130X_mcRun3_2022_realistic_postEE_v6-v2/40000/ffcd4b23-808d-43e5-9b08-46506cbccc75.root"
 
     # configure and compile the project
     if [[ "${steps}" == "build" || "${steps}" == "all" ]]; then

--- a/nmssm_config.py
+++ b/nmssm_config.py
@@ -3112,7 +3112,8 @@ def build_config(
             q.dilepton_veto,
         ] + scalefactors.EleID_SF.get_outputs("em")
         + scalefactors.MuonIDIso_SF.get_outputs("em")
-        + scalefactors.SingleEleTriggerSF.get_outputs("em"),
+        + scalefactors.SingleEleTriggerSF.get_outputs("em")
+        + scalefactors.SingleMuTriggerSF.get_outputs("em"),
     )
 
     # TODO re-include

--- a/nmssm_config.py
+++ b/nmssm_config.py
@@ -2026,6 +2026,20 @@ def build_config(
         era,
     )
 
+    # Di-tau + jet trigger
+    # - In Run 2, di-tau + jet triggers did not exist, so no producer is added.
+    # - In Run 3, di-tau + jet triggers are available and the corresponding trigger flag producers
+    #   are added to the tt scope.
+    double_tau_jet_trigger_producers = get_for_era(
+        {
+            tuple(ERAS_RUN3): [
+                triggers.DoubleTauTauJetTriggerFlags,
+            ],
+        },
+        era,
+        default=[],
+    )
+
     # Tau ID scale factors in the mt channel
     # - In Run 2, the scale factors are provided from own measurements with the same methods as for
     #   embedding.
@@ -2251,6 +2265,7 @@ def build_config(
             # triggers.GenerateSingleTrailingTauTriggerFlags,
             # triggers.GenerateSingleLeadingTauTriggerFlags,
         ]
+        + double_tau_jet_trigger_producers
         + tt_tau_sf_producers
     )
 

--- a/nmssm_config.py
+++ b/nmssm_config.py
@@ -2324,6 +2324,7 @@ def build_config(
             scalefactors.MuonIDIso_SF,
             triggers.SingleEleTriggerFlags,
             triggers.SingleMuTriggerFlags,
+            triggers.DoubleEleMuTriggerFlags,
             scalefactors.SingleEleTriggerSF,
             scalefactors.SingleMuTriggerSF,
         ],
@@ -3079,6 +3080,7 @@ def build_config(
             triggers.SingleMuTriggerFlags.output_group,
             q.muon_veto_flag,
             q.electron_veto_flag,
+            q.dielectron_veto,
         ] + scalefactors.MuonIDIso_SF.get_outputs("mm")
         + scalefactors.SingleMuTriggerSF.get_outputs("mm"),
     )
@@ -3091,10 +3093,26 @@ def build_config(
             triggers.SingleEleTriggerFlags.output_group,
             q.muon_veto_flag,
             q.electron_veto_flag,
-            q.dielectron_veto,
-            q.dilepton_veto,
+            q.dimuon_veto,
         ] + scalefactors.EleID_SF.get_outputs("ee")
         + scalefactors.SingleEleTriggerSF.get_outputs("ee"),
+    )
+
+    # Outputs for the em scope
+    configuration.add_outputs(
+        "em",
+        [
+            q.nelectrons,
+            q.nmuons,
+            triggers.SingleEleTriggerFlags.output_group,
+            triggers.SingleMuTriggerFlags.output_group,
+            triggers.DoubleEleMuTriggerFlags.output_group,
+            q.electron_veto_flag,
+            q.muon_veto_flag,
+            q.dilepton_veto,
+        ] + scalefactors.EleID_SF.get_outputs("em")
+        + scalefactors.MuonIDIso_SF.get_outputs("em")
+        + scalefactors.SingleEleTriggerSF.get_outputs("em"),
     )
 
     # TODO re-include

--- a/producers/triggers.py
+++ b/producers/triggers.py
@@ -2,7 +2,7 @@ from ..quantities import output as q
 from ..quantities import nanoAOD as nanoAOD
 from code_generation.producer import ExtendedVectorProducer
 
-from ..constants import ET_SCOPES, MT_SCOPES, TT_SCOPES, ELECTRON_SCOPES, MUON_SCOPES
+from ..constants import ET_SCOPES, MT_SCOPES, TT_SCOPES, EM_SCOPES, ELECTRON_SCOPES, MUON_SCOPES
 
 
 #
@@ -109,6 +109,29 @@ DoubleTauTauTriggerFlags = ExtendedVectorProducer(
     vec_config="double_tautau_trigger",
 )
 
+
+#
+# DOBULE ELECTRON-MUON TRIGGERS
+#
+
+
+# double electron-muon trigger flags, including trigger object matching
+DoubleEleMuTriggerFlags = ExtendedVectorProducer(
+    name="DoubleEleMuTriggerFlags",
+    call='trigger::GenerateDoubleTriggerFlag({df}, {output}, {input}, "{hlt_path}", {p1_min_pt}, {p2_min_pt}, {p1_max_abs_eta}, {p2_max_abs_eta}, {p1_particle_id}, {p2_particle_id}, {p1_filter_bit}, {p2_filter_bit}, {match_max_delta_r})',
+    input=[
+        q.p4_1,
+        q.p4_2,
+        nanoAOD.TrigObj_filterBits,
+        nanoAOD.TrigObj_id,
+        nanoAOD.TrigObj_pt,
+        nanoAOD.TrigObj_eta,
+        nanoAOD.TrigObj_phi,
+    ],
+    output="flagname",
+    scope=EM_SCOPES,
+    vec_config="double_ele_mu_trigger",
+)
 
 ####################
 # Set of producers used for trigger flags

--- a/producers/triggers.py
+++ b/producers/triggers.py
@@ -118,15 +118,15 @@ DoubleTauTauTriggerFlags = ExtendedVectorProducer(
 # double electron-muon trigger flags, including trigger object matching
 DoubleEleMuTriggerFlags = ExtendedVectorProducer(
     name="DoubleEleMuTriggerFlags",
-    call='trigger::GenerateDoubleTriggerFlag({df}, {output}, {input}, "{hlt_path}", {p1_min_pt}, {p2_min_pt}, {p1_max_abs_eta}, {p2_max_abs_eta}, {p1_particle_id}, {p2_particle_id}, {p1_filter_bit}, {p2_filter_bit}, {match_max_delta_r})',
+    call='trigger::DoubleObjectFlag({df}, {output}, {input}, "{hlt_path}", {p1_min_pt}, {p2_min_pt}, {p1_max_abs_eta}, {p2_max_abs_eta}, {p1_particle_id}, {p2_particle_id}, {p1_filter_bit}, {p2_filter_bit}, {match_max_delta_r})',
     input=[
         q.p4_1,
         q.p4_2,
-        nanoAOD.TrigObj_filterBits,
-        nanoAOD.TrigObj_id,
         nanoAOD.TrigObj_pt,
         nanoAOD.TrigObj_eta,
         nanoAOD.TrigObj_phi,
+        nanoAOD.TrigObj_id,
+        nanoAOD.TrigObj_filterBits,
     ],
     output="flagname",
     scope=EM_SCOPES,

--- a/producers/triggers.py
+++ b/producers/triggers.py
@@ -109,6 +109,24 @@ DoubleTauTauTriggerFlags = ExtendedVectorProducer(
     vec_config="double_tautau_trigger",
 )
 
+# double tau-tau + jet trigger flags, including trigger object matching
+DoubleTauTauJetTriggerFlags = ExtendedVectorProducer(
+    name="DoubleTauTauJetTriggerFlags",
+    call='trigger::DoubleObjectFlag({df}, {output}, {input}, "{hlt_path}", {p1_min_pt}, {p2_min_pt}, {p1_max_abs_eta}, {p2_max_abs_eta}, {p1_particle_id}, {p2_particle_id}, {p1_filter_bit}, {p2_filter_bit}, {match_max_delta_r})',
+    input=[
+        q.p4_1,
+        q.p4_2,
+        nanoAOD.TrigObj_pt,
+        nanoAOD.TrigObj_eta,
+        nanoAOD.TrigObj_phi,
+        nanoAOD.TrigObj_id,
+        nanoAOD.TrigObj_filterBits,
+    ],
+    output="flagname",
+    scope=TT_SCOPES,
+    vec_config="double_tautau_jet_trigger",
+)
+
 
 #
 # DOBULE ELECTRON-MUON TRIGGERS

--- a/tau_triggersetup.py
+++ b/tau_triggersetup.py
@@ -671,9 +671,37 @@ def add_diTauTriggerSetup(configuration: Configuration):
     configuration.add_config_parameters(
         TT_SCOPES,
         {
+            "double_tautau_jet_trigger": EraModifier(
+                {
+                    **{
+                        _era: [
+                            # trigger:        HLT_DoubleMediumDeepTauPFTauHPS35_L2NN_eta2p1
+                            # final filter:   hltHpsOverlapFilterDeepTauDoublePFTau30PFJet60
+                            # filter bit:     3, 14
+                            # documentation:  https://twiki.cern.ch/twiki/bin/view/CMS/TauTrigger#Trigger_Table_for_2022
+                            {
+                                "flagname": "trg_double_tau30_jet60",
+                                "hlt_path": "HLT_DoubleMediumDeepTauPFTauHPS30_L2NN_eta2p1_PFJet60",
+                                "p1_min_pt": 35.,
+                                "p1_max_abs_eta": 2.1,
+                                "p1_filter_bit": 14,
+                                "p1_particle_id": 15,
+                                "p2_min_pt": 35.,
+                                "p2_max_abs_eta": 2.1,
+                                "p2_filter_bit": 14,
+                                "p2_particle_id": 15,
+                                "match_max_delta_r": 0.4,
+                            },
+                        ]
+                        for _era in ERAS_RUN3
+                    },
+                    **{
+                        _era: [] for _era in ERAS_RUN2  # These triggers do not exist for Run 2
+                    },
+                },
+            ),
             "double_tautau_trigger": EraModifier(
                 {
-                    # TODO placeholder for Run3 eras, add these triggers also there
                     **{
                         _era: [
                             # trigger:        HLT_DoubleMediumDeepTauPFTauHPS35_L2NN_eta2p1

--- a/tau_triggersetup.py
+++ b/tau_triggersetup.py
@@ -1,7 +1,7 @@
 from code_generation.configuration import Configuration
 from code_generation.modifiers import EraModifier
 
-from .constants import ET_SCOPES, MT_SCOPES, TT_SCOPES, ELECTRON_SCOPES, MUON_SCOPES, ERAS_RUN2, ERAS_RUN3, CORRECTIONLIB_CAMPAIGNS
+from .constants import EM_SCOPES, ET_SCOPES, MT_SCOPES, TT_SCOPES, ELECTRON_SCOPES, MUON_SCOPES, ERAS_RUN2, ERAS_RUN3, CORRECTIONLIB_CAMPAIGNS
 
 
 def add_diTauTriggerSetup(configuration: Configuration):
@@ -995,6 +995,57 @@ def add_diTauTriggerSetup(configuration: Configuration):
                 }
             ),
         },
+    )
+
+    ## electron-muon cross triggers for the em control channel
+    configuration.add_config_parameters(
+        EM_SCOPES,
+        {
+            "double_ele_mu_trigger": EraModifier(
+                {
+                    **{
+                        _era: [
+                            # trigger:            HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL
+                            # final filter:       hltMu8TrkIsoVVLEle23CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter
+                            # filter bit:         5 for electron and muon leg
+                            # documentation:      ???
+                            {
+                                "flagname": "trg_double_mu8_ele23",
+                                "hlt_path": "HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL",
+                                "p1_min_pt": 10,
+                                "p2_min_pt": 25,
+                                "p1_max_abs_eta": 2.4,
+                                "p2_max_abs_eta": 2.5,
+                                "p1_filter_bit": 5,
+                                "p2_filter_bit": 5,
+                                "p1_particle_id": 13,
+                                "p2_particle_id": 11,
+                                "match_max_delta_r": 0.4,
+                            },
+
+                            # trigger:            HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL
+                            # final filter:       hltMu23TrkIsoVVLEle12CaloIdLTrackIdLIsoVLElectronlegTrackIsoFilter
+                            # filter bit:         5 for electron and muon leg
+                            # documentation:      ???
+                            {
+                                "flagname": "trg_double_mu23_ele12",
+                                "hlt_path": "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL",
+                                "p1_min_pt": 25,
+                                "p2_min_pt": 14,
+                                "p1_max_abs_eta": 2.4,
+                                "p2_max_abs_eta": 2.5,
+                                "p1_filter_bit": 5,
+                                "p2_filter_bit": 5,
+                                "p1_particle_id": 13,
+                                "p2_particle_id": 11,
+                                "match_max_delta_r": 0.4,
+                            },
+                        ]
+                        for _era in ["2022preEE", "2022postEE", "2023preBPix", "2023postBPix"]
+                    },
+                }
+            ),
+        }
     )
 
     # single electron trigger scale factors


### PR DESCRIPTION
This pull request adds additional triggers for further studies to the analysis configuration.

- A di-tau + jet trigger is added to the $\tau_{\text{h}}\tau_{\text{h}}$ channel.
- A electron+muon cross trigger is added to the $\text{e}\mu$ channel.

The trigger scale factors for these paths will be included at a later point if we decide to include the triggers in the analysis.