### PR TITLE
Fixes on electron ID, single-muon trigger, and filtering

### DIFF
--- a/nmssm_config.py
+++ b/nmssm_config.py
@@ -306,7 +306,7 @@ def add_electron_config(configuration: Configuration):
     :param configuration: the main configuration object
     :type configuration: Configuration
 
-    :param electron_id_loose: name of the electron ID for the loose electron collection; default: `"Electron_mvaNoIso_WP90"`.
+    :param electron_id_loose: name of the electron ID for the loose electron collection; default: `"Electron_mvaIso_WP90"`.
     :type electron_id_loose: str
 
     :param electron_id_loose_corrlib: name of the electron ID for the loose electron collection in the EGM correctionlib file; default: `"wp90noiso"`.
@@ -322,7 +322,7 @@ def add_electron_config(configuration: Configuration):
             "loose_electron_max_abs_dxy": 0.045,
             "loose_electron_max_abs_dz": 0.2,
             "loose_electron_max_iso": 0.25,
-            "loose_electron_id": "Electron_mvaNoIso_WP90",  # NanoAOD v9: Electron_mvaFall17V2noIso_WP90
+            "loose_electron_id": "Electron_mvaIso_WP90",  # NanoAOD v9: Electron_mvaFall17V2noIso_WP90
         },
     )
 
@@ -349,7 +349,7 @@ def add_electron_config(configuration: Configuration):
             "tight_electron_max_abs_dxy": 0.045,
             "tight_electron_max_abs_dz": 0.2,
             "tight_electron_max_iso": 0.4,
-            "tight_electron_id": "Electron_mvaNoIso_WP90",  # NanoAOD v9: Electron_mvaFall17V2noIso_WP90,
+            "tight_electron_id": "Electron_mvaIso_WP90",  # NanoAOD v9: Electron_mvaFall17V2noIso_WP90,
         },
     )
 
@@ -529,7 +529,6 @@ def add_muon_config(configuration: Configuration):
             "tight_muon_max_abs_dz": 0.2,
             "tight_muon_max_iso": 0.4,
             "tight_muon_id": "Muon_mediumId",
-            "muon_index_in_pair": 0,
         },
     )
 
@@ -541,7 +540,7 @@ def add_muon_config(configuration: Configuration):
         },
     )
 
-    # In the em scope, the first lepton is a muon
+    # In the em scope, the second lepton is a muon
     configuration.add_config_parameters(
         EM_SCOPES,
         {

--- a/nmssm_config.py
+++ b/nmssm_config.py
@@ -411,7 +411,7 @@ def add_electron_config(configuration: Configuration):
                 }
             ),
             "ele_reco_sf_name": "RecoAbove20",  # TODO needs to be modified for 2022 and 2023
-            "ele_id_sf_name": "wp90noiso",
+            "ele_id_sf_name": "wp90iso",
             "ele_reco_sf_variation": "sf",  # "sf" is nominal, "sfup"/"sfdown" are up/down variations
             "ele_id_sf_variation": "sf",  # "sf" is nominal, "sfup"/"sfdown" are up/down variations
         },

--- a/nmssm_config.py
+++ b/nmssm_config.py
@@ -2513,7 +2513,7 @@ def build_config(
             electrons.NumberOfGoodElectrons,
             muons.NumberOfGoodMuons,
             pairselection.EMPairSelection,
-            pairselection.GoodEMPairFlag,
+            pairselection.GoodEMPairFilter,
             pairselection.LVEl1,
             pairselection.LVMu2,
             pairselection.LVEl1Uncorrected,

--- a/producers/scalefactors.py
+++ b/producers/scalefactors.py
@@ -731,10 +731,11 @@ SingleEleTriggerSF = ExtendedVectorProducer(
 SingleMuTriggerSF = ExtendedVectorProducer(
     name="SingleMuTriggerSF",
     call='physicsobject::muon::scalefactor::Trigger({df}, correctionManager, {output}, {input}, "{m_trigger_flag}", "{muon_sf_file}", "{m_trigger_sf_name}", "{m_trigger_variation}")',
-    input=[
-        q.pt_1,
-        q.eta_1,
-    ],
+    input={
+        "mt": [q.pt_1, q.eta_1],
+        "mm": [q.pt_1, q.eta_1],
+        "em": [q.pt_2, q.eta_2],
+    },
     output="m_trigger_flagname",
     scope=MUON_SCOPES,
     vec_config="single_mu_trigger_sf",

--- a/producers/triggers.py
+++ b/producers/triggers.py
@@ -73,17 +73,21 @@ SingleMuTriggerFlags = ExtendedVectorProducer(
 )
 
 # single muon trigger flags, including trigger object matching
+common_inputs = [
+    nanoAOD.TrigObj_pt,
+    nanoAOD.TrigObj_eta,
+    nanoAOD.TrigObj_phi,
+    nanoAOD.TrigObj_id,
+    nanoAOD.TrigObj_filterBits,
+]
 SingleMuTriggerFlags = ExtendedVectorProducer(
     name="SingleMuTriggerFlags",
     call='trigger::SingleObjectFlag({df}, {output}, {input}, "{hlt_path}", {min_pt}, {max_abs_eta}, {particle_id}, {filter_bit}, {match_max_delta_r})',
-    input=[
-        q.p4_1,
-        nanoAOD.TrigObj_pt,
-        nanoAOD.TrigObj_eta,
-        nanoAOD.TrigObj_phi,
-        nanoAOD.TrigObj_id,
-        nanoAOD.TrigObj_filterBits,
-    ],
+    input={
+        "mt": [q.p4_1, ] + common_inputs,
+        "mm": [q.p4_1, ] + common_inputs,
+        "em": [q.p4_2, ] + common_inputs,
+    },
     output="flagname",
     scope=MUON_SCOPES,
     vec_config="single_mu_trigger",

--- a/producers/triggers.py
+++ b/producers/triggers.py
@@ -72,27 +72,6 @@ SingleMuTriggerFlags = ExtendedVectorProducer(
     vec_config="single_mu_trigger",
 )
 
-# single muon trigger flags, including trigger object matching
-common_inputs = [
-    nanoAOD.TrigObj_pt,
-    nanoAOD.TrigObj_eta,
-    nanoAOD.TrigObj_phi,
-    nanoAOD.TrigObj_id,
-    nanoAOD.TrigObj_filterBits,
-]
-SingleMuTriggerFlags = ExtendedVectorProducer(
-    name="SingleMuTriggerFlags",
-    call='trigger::SingleObjectFlag({df}, {output}, {input}, "{hlt_path}", {min_pt}, {max_abs_eta}, {particle_id}, {filter_bit}, {match_max_delta_r})',
-    input={
-        "mt": [q.p4_1, ] + common_inputs,
-        "mm": [q.p4_1, ] + common_inputs,
-        "em": [q.p4_2, ] + common_inputs,
-    },
-    output="flagname",
-    scope=MUON_SCOPES,
-    vec_config="single_mu_trigger",
-)
-
 # double muon-tau trigger flags, including trigger object matching
 DoubleMuTauTriggerFlags = ExtendedVectorProducer(
     name="DoubleMuTauTriggerFlags",

--- a/producers/triggers.py
+++ b/producers/triggers.py
@@ -52,6 +52,27 @@ DoubleEleTauTriggerFlags = ExtendedVectorProducer(
 
 
 # single muon trigger flags, including trigger object matching
+common_inputs = [
+    nanoAOD.TrigObj_pt,
+    nanoAOD.TrigObj_eta,
+    nanoAOD.TrigObj_phi,
+    nanoAOD.TrigObj_id,
+    nanoAOD.TrigObj_filterBits,
+]
+SingleMuTriggerFlags = ExtendedVectorProducer(
+    name="SingleMuTriggerFlags",
+    call='trigger::SingleObjectFlag({df}, {output}, {input}, "{hlt_path}", {min_pt}, {max_abs_eta}, {particle_id}, {filter_bit}, {match_max_delta_r})',
+    input={
+        "mt": [q.p4_1] + common_inputs,
+        "mm": [q.p4_1] + common_inputs,
+        "em": [q.p4_2] + common_inputs,
+    },
+    output="flagname",
+    scope=MUON_SCOPES,
+    vec_config="single_mu_trigger",
+)
+
+# single muon trigger flags, including trigger object matching
 SingleMuTriggerFlags = ExtendedVectorProducer(
     name="SingleMuTriggerFlags",
     call='trigger::SingleObjectFlag({df}, {output}, {input}, "{hlt_path}", {min_pt}, {max_abs_eta}, {particle_id}, {filter_bit}, {match_max_delta_r})',


### PR DESCRIPTION
This pull request changes the electron ID and fixes a bug in the single-muon trigger matching in the $e\mu$ channel.

- [x] The electron ID is changed to `Electron_mvaIso_WP90`.
- [x] For the matching with the single-muon trigger, the second lepton is now used instead of the first lepton in the $e\mu$ channel.
- [x] In the $e\mu$ channel, the filter for events with successful pair selection is activated. Before, events were just flagged, but not filtered.