### PR TITLE
Adaptions for Run 2 NANOAOD v15

### DIFF
--- a/nmssm_config.py
+++ b/nmssm_config.py
@@ -2329,26 +2329,16 @@ def build_config(
     )
 
     # Electron pt correction
-    # - In Run 2, a fix must be applied to the already corrected electron pt.
-    # - In Run 3, the electon pt is not corrected at NanoAOD level, the full correction is applied
-    #   based on correctionlib files.
-    electron_pt_correction_mc_producer = get_for_era(
-        {
-            tuple(ERAS_RUN2): electrons.ElectronPtCorrectionMCRun2,
-            tuple(ERAS_RUN3): electrons.ElectronPtCorrectionMCRun3,
-        },
-        era,
-    )
-
-    # Electron pt correction for data
-    # - In Run 2, the pt is already corrected, so this is just 
-    electron_pt_correction_data_producer = get_for_era(
-        {
-            tuple(ERAS_RUN2): electrons.RenameElectronPt,
-            tuple(ERAS_RUN3): electrons.ElectronPtCorrectionDataRun3,
-        },
-        era,
-    )
+    #
+    # See comments in corresponding producers: For Run 2, the corrections on
+    # NANOAOD v15 samples are not available yet (the procedure has changed
+    # between NanoAODv9 and NanoAODv15). Currently, the Run 2 producers just
+    # rename the electron pt in NANOAOD.
+    #
+    # TODO As soon as dedicated corrections are available, implement the
+    # Run 3 procedure also for Run 2 eras.
+    ElectronPtCorrectionMC = get_for_era(electrons.ElectronPtCorrectionMC)
+    ElectronPtCorrectionData = get_for_era(electrons.ElectronPtCorrectionData)
 
     # Jet ID producer
     # For a detailed description, see producers/jets.py
@@ -2533,7 +2523,7 @@ def build_config(
         # + fat_jet_id_producers
         + jet_veto_map_producers
         + [
-            electron_pt_correction_mc_producer,
+            ElectronPtCorrectionMC,
             jets.JERSmearingSeed,
             jets.JetEnergyCorrectionMC,
             # fatjets.FatJetEnergyCorrection,
@@ -2970,8 +2960,8 @@ def build_config(
         GLOBAL_SCOPES,
         ReplaceProducer(
             producers=[
-                electron_pt_correction_mc_producer,
-                electron_pt_correction_data_producer,
+                ElectronPtCorrectionMC,
+                ElectronPtCorrectionData,
             ],
             samples=["data"],
         ),

--- a/nmssm_config.py
+++ b/nmssm_config.py
@@ -2337,8 +2337,8 @@ def build_config(
     #
     # TODO As soon as dedicated corrections are available, implement the
     # Run 3 procedure also for Run 2 eras.
-    ElectronPtCorrectionMC = get_for_era(electrons.ElectronPtCorrectionMC)
-    ElectronPtCorrectionData = get_for_era(electrons.ElectronPtCorrectionData)
+    ElectronPtCorrectionMC = get_for_era(electrons.ElectronPtCorrectionMC, era)
+    ElectronPtCorrectionData = get_for_era(electrons.ElectronPtCorrectionData, era)
 
     # Jet ID producer
     # For a detailed description, see producers/jets.py

--- a/producers/electrons.py
+++ b/producers/electrons.py
@@ -100,7 +100,7 @@ ElectronPtCorrectionData = {
         output=[q.Electron_pt_corrected],
         scopes=GLOBAL_SCOPES,
     ),
-    tuple(ERAS_RUN3): ProducerGroup(
+    tuple(ERAS_RUN3): Producer(
         name="ElectronPtCorrectionData",
         call='physicsobject::electron::PtCorrectionData({df}, correctionManager, {output}, {input}, "{ele_es_file}", "{ele_es_sf_data_name}")',
         input=[

--- a/producers/electrons.py
+++ b/producers/electrons.py
@@ -6,7 +6,7 @@ from ..quantities import output as q
 from ..quantities import nanoAOD, nanoAOD_run2
 from code_generation.producer import Producer, ProducerGroup
 
-from ..constants import EE_SCOPES, ET_SCOPES, ELECTRON_SCOPES, SCOPES, GLOBAL_SCOPES
+from ..constants import EE_SCOPES, ET_SCOPES, ELECTRON_SCOPES, SCOPES, GLOBAL_SCOPES, ERAS_RUN2, ERAS_RUN3
 
 
 #
@@ -14,7 +14,8 @@ from ..constants import EE_SCOPES, ET_SCOPES, ELECTRON_SCOPES, SCOPES, GLOBAL_SC
 #
 
 
-# corrections in embedding samples
+# TODO Probably needs to be reworked, depending on the structure of upcoming
+# embedding corrections
 ElectronPtCorrectionEmbedding = Producer(
     name="ElectronPtCorrectionEmbedding",
     call='embedding::electron::PtCorrection({df}, correctionManager, {output}, {input}, "{embedding_electron_es_sf_file}", "{ele_ES_json_name}", "{ele_energyscale_barrel}", "{ele_energyscale_endcap}")',
@@ -26,7 +27,10 @@ ElectronPtCorrectionEmbedding = Producer(
     scopes=GLOBAL_SCOPES,
 )
 
-# corrections in MC samples in Run 2, for which an additional scale factor file needs to be provided
+
+# TODO Deprecated producer, remove this producer when NANOAODv9/v12 samples are
+# not used anymore. Corrections in MC samples in Run 2, for which an additional
+# scale factor file needs to be provided.
 ElectronPtCorrectionMCRun2 = Producer(
     name="ElectronPtCorrectionMCRun2",
     call='physicsobject::electron::PtCorrectionMC({df}, correctionManager, {output}, {input}, "{ele_es_file}", "{ele_es_sf_name}", "{ele_es_era}", "{ele_es_variation}")',
@@ -41,23 +45,8 @@ ElectronPtCorrectionMCRun2 = Producer(
     scopes=GLOBAL_SCOPES,
 )
 
-# electron scale correction for data in Run 3
-ElectronPtCorrectionDataRun3 = Producer(
-    name="ElectronPtCorrectionDataRun3",
-    call='physicsobject::electron::PtCorrectionData({df}, correctionManager, {output}, {input}, "{ele_es_file}", "{ele_es_sf_data_name}")',
-    input=[
-        nanoAOD.Electron_pt,
-        nanoAOD.Electron_eta,
-        nanoAOD.Electron_deltaEtaSC,
-        nanoAOD.Electron_seedGain,
-        nanoAOD.Electron_r9,
-        nanoAOD.run
-    ],
-    output=[q.Electron_pt_corrected],
-    scopes=GLOBAL_SCOPES,
-)
 
-# event seed for initializing the smearing
+# Event seed for initializing the smearing (needed for Run 3 MC corrections)
 ElectronPtSmearingSeed = Producer(
     name="ElectronPtSmearingSeed",
     call="event::quantity::GenerateSeed({df}, {output}, {input}, {ele_es_master_seed})",
@@ -70,29 +59,62 @@ ElectronPtSmearingSeed = Producer(
     scopes=GLOBAL_SCOPES,
 )
 
-# electron scale and resolution correction for MC in Run 3
-ElectronPtCorrectionMCRun3 = ProducerGroup(
-    name="ElectronPtCorrectionMCRun3",
-    call='physicsobject::electron::PtCorrectionMC({df}, correctionManager, {output}, {input}, "{ele_es_file}", "{ele_es_sf_mc_name}", "{ele_es_variation}")',
-    input=[
-        nanoAOD.Electron_pt,
-        nanoAOD.Electron_eta,
-        nanoAOD.Electron_deltaEtaSC,
-        nanoAOD.Electron_r9,
-    ],
-    output=[q.Electron_pt_corrected],
-    scopes=GLOBAL_SCOPES,
-    subproducers=[ElectronPtSmearingSeed],
-)
 
-# dummy corrections for cases in which corrections are already applied on NanoAOD level (just rename column)
-RenameElectronPt = Producer(
-    name="RenameElectronPt",
-    call="event::quantity::Rename<ROOT::RVec<float>>({df}, {output}, {input})",
-    input=[nanoAOD.Electron_pt],
-    output=[q.Electron_pt_corrected],
-    scopes=GLOBAL_SCOPES,
-)
+# Electron pt correction on MC events
+ElectronPtCorrectionMC = {
+    # TODO The Run 2 electron p_T corrections for NANOAOD v15 still need to be
+    # implemented. The corresponding correctionlib files have not been made
+    # available yet.
+    tuple(ERAS_RUN2): Producer(
+        name="ElectronPtCorrectionMC",
+        call="event::quantity::Rename<ROOT::RVec<float>>({df}, {output}, {input})",
+        input=[nanoAOD.Electron_pt],
+        output=[q.Electron_pt_corrected],
+        scopes=GLOBAL_SCOPES,
+    ),
+    tuple(ERAS_RUN3): ProducerGroup(
+        name="ElectronPtCorrectionMC",
+        call='physicsobject::electron::PtCorrectionMC({df}, correctionManager, {output}, {input}, "{ele_es_file}", "{ele_es_sf_mc_name}", "{ele_es_variation}")',
+        input=[
+            nanoAOD.Electron_pt,
+            nanoAOD.Electron_eta,
+            nanoAOD.Electron_deltaEtaSC,
+            nanoAOD.Electron_r9,
+        ],
+        output=[q.Electron_pt_corrected],
+        scopes=GLOBAL_SCOPES,
+        subproducers=[ElectronPtSmearingSeed],
+    ),
+}
+
+
+# Electron pt correction on data events
+ElectronPtCorrectionData = {
+    # TODO The Run 2 electron p_T corrections for NANOAOD v15 still need to be
+    # implemented. The corresponding correctionlib files have not been made
+    # available yet.
+    tuple(ERAS_RUN2): Producer(
+        name="ElectronPtCorrectionData",
+        call="event::quantity::Rename<ROOT::RVec<float>>({df}, {output}, {input})",
+        input=[nanoAOD.Electron_pt],
+        output=[q.Electron_pt_corrected],
+        scopes=GLOBAL_SCOPES,
+    ),
+    tuple(ERAS_RUN3): ProducerGroup(
+        name="ElectronPtCorrectionData",
+        call='physicsobject::electron::PtCorrectionData({df}, correctionManager, {output}, {input}, "{ele_es_file}", "{ele_es_sf_data_name}")',
+        input=[
+            nanoAOD.Electron_pt,
+            nanoAOD.Electron_eta,
+            nanoAOD.Electron_deltaEtaSC,
+            nanoAOD.Electron_seedGain,
+            nanoAOD.Electron_r9,
+            nanoAOD.run
+        ],
+        output=[q.Electron_pt_corrected],
+        scopes=GLOBAL_SCOPES,
+    ),
+}
 
 
 #


### PR DESCRIPTION
This pull request collects changes that are needed to run a NTuple production on Run 2 NANOAODv15 samples. Changes, that currently cannot be implemented, e.g., due to missing corrections or inputs, are collected in issue https://github.com/KIT-CMS/BBTauTauAnalysis-CROWN/issues/39.

### Electrons

The format of electron $p_{\mathrm{T}}$ corrections has been changed between NANOAOD v9 and NANOAOD v15. Now, the corrections must be applied to data and MC, corresponding scale and resolution corrections are taken from a correctionlib file. These corrections are not provided yet by the EGM POG. Thus, for Run 2 samples, the electron $p_{\text{T}}$ correction is currently not performed, we just take the value from the NANOAOD.